### PR TITLE
Use native promises for Bridge/Controller

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,8 +11,8 @@
     - [.mount(zApp, callback)](#mountzapp-callback)
     - [.list([ieeeAddrs])](#listieeeaddrs)
     - [.find(addr, epId)](#findaddr-epid)
-    - [.lqi(ieeeAddr, callback)](#lqiieeeaddr-callback)
-    - [.remove(ieeeAddr[, cfg][, callback])](#removeieeeaddr-cfg-callback)
+    - [.lqi(ieeeAddr)](#lqiieeeaddr)
+    - [.remove(ieeeAddr[, cfg])](#removeieeeaddr-cfg)
     - [.acceptDevIncoming(devInfo, callback)](#acceptdevincomingdevinfo-callback)
     - [Event: 'ready'](#event-ready)
     - [Event: 'error'](#event-error)
@@ -369,7 +369,6 @@ Query the link quality index from a certain device by its ieee address.
 **Arguments:**
 
 1. `ieeeAddr` (_String_): Ieee address of the device.
-2. `callback` (_Function_): `function (err, data) { }`. This method returns you the link quality index via `data`. An error occurs if device not found.
 
 **Returns:**
 
@@ -378,10 +377,9 @@ Query the link quality index from a certain device by its ieee address.
 **Examples:**
 
 ```js
-bridge.lqi('0x00124b0001ce4beb', (err, data) => {
-  if (!err) {
-    console.log(data);
-    /*
+bridge.lqi('0x00124b0001ce4beb')
+  .then(() => console.log(data));
+  /*
     [
       {
         ieeeAddr: '0x00124b0001ce3631',
@@ -392,14 +390,12 @@ bridge.lqi('0x00124b0001ce4beb', (err, data) => {
         lqi: 70
       }
     ]
-    */
-  }
-});
+  */
 ```
 
 ********************************************
 
-### .remove(ieeeAddr[, cfg][, callback])
+### .remove(ieeeAddr[, cfg])
 
 Remove the device from the network.
 
@@ -409,7 +405,6 @@ Remove the device from the network.
 2. `cfg` (_Object_):
     - `reJoin` (_Boolean_): Set to `true` if device is allowed for re-joining, otherwise `false`. Default is `true`.
     - `rmChildren` (_Boolean_): Set to `true` will remove all children of this device as well. Default is `false`.
-3. `callback` (_Function_): `function (err) { }`.
 
 **Returns:**
 
@@ -418,18 +413,12 @@ Remove the device from the network.
 **Examples:**
 
 ```js
-bridge.remove('0x00124b0001ce4beb', (err) => {
-  if (!err) {
-    console.log('Successfully removed!');
-  }
-});
+bridge.remove('0x00124b0001ce4beb')
+  .then(() => console.log('Successfully removed!'));
 
 // remove and ban [TODO: how to unban???]
-bridge.remove('0x00124b0001ce4beb', { reJoin: false }, (err) => {
-  if (!err) {
-    console.log('Successfully removed!');
-  }
-});
+bridge.remove('0x00124b0001ce4beb', { reJoin: false })
+  .then(() => console.log('Successfully removed!'));
 ```
 
 ********************************************

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -459,24 +459,20 @@ module.exports = class Bridge extends EventEmitter {
             });
     }
 
-    remove(ieeeAddr, cfg, callback) {
-        proving.string(ieeeAddr, 'ieeeAddr should be a string.');
+    remove(ieeeAddr, cfg = {}) {
+        return Promise.resolve()
+            .then(() => {
+                proving.string(ieeeAddr, 'ieeeAddr should be a string.');
+            })
+            .then(() => this._findDevByAddr(ieeeAddr))
+            .then((dev) => {
+                if (!dev) {
+                    throw new Error('device is not found.');
+                }
 
-        const dev = this._findDevByAddr(ieeeAddr);
-
-        if (_.isFunction(cfg) && !_.isFunction(callback)) {
-            callback = cfg;
-            cfg = {};
-        } else {
-            cfg = cfg || {};
-        }
-
-        if (!dev) {
-            return Q.reject(new Error('device is not found.'))
-                .nodeify(callback);
-        }
-
-        return this.controller.remove(dev, cfg, callback);
+                return dev;
+            })
+            .then((dev) => this.controller.remove(dev, cfg));
     }
 
     /*

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -345,9 +345,10 @@ module.exports = class Bridge extends EventEmitter {
                 throw new Error('Coordinator has not been initialized yet.');
             }
         }).then(() => {
-            return this.controller.registerEp(loEp).then(function() {
-                debug.bridge('Register zApp, epId: %s, profId: %s ', loEp.getEpId(), loEp.getProfId());
-            });
+            return this.controller.registerEp(loEp)
+                .then(() => {
+                    debug.bridge('Register zApp, epId: %s, profId: %s ', loEp.getEpId(), loEp.getProfId());
+                });
         }).then(() => {
             return this.controller.querie.coordInfo()
                 .then((coordInfo) => {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -430,32 +430,33 @@ module.exports = class Bridge extends EventEmitter {
             : undefined;
     }
 
-    lqi(ieeeAddr, callback) {
-        proving.string(ieeeAddr, 'ieeeAddr should be a string.');
+    lqi(ieeeAddr) {
+        return Promise.resolve()
+            .then(() => {
+                proving.string(ieeeAddr, 'ieeeAddr should be a string.');
+            })
+            .then(() => this._findDevByAddr(ieeeAddr))
+            .then((dev) => {
+                if (!dev) {
+                    throw new Error('device is not found.');
+                }
 
-        const dev = this._findDevByAddr(ieeeAddr);
+                return dev;
+            })
+            .then((dev) => this.controller.request('ZDO', 'mgmtLqiReq', {
+                dstaddr: dev.getNwkAddr(),
+                startindex: 0,
+            }))
+            .then((rsp) => {
+                // { srcaddr, status, neighbortableentries, startindex, neighborlqilistcount, neighborlqilist }
+                if (rsp.status !== 0) return;
 
-        return Q.fcall(() => {
-            if (dev) {
-                return this.controller.request('ZDO', 'mgmtLqiReq', {
-                    dstaddr: dev.getNwkAddr(),
-                    startindex: 0,
-                });
-            }
-
-            return Q.reject(new Error('device is not found.'));
-        }).then(function(rsp) {
-            // { srcaddr, status, neighbortableentries, startindex, neighborlqilistcount, neighborlqilist }
-            if (rsp.status !== 0) return;
-
-            // success
-            return _.map(rsp.neighborlqilist, (neighbor) => {
-                return {
+                // success
+                return rsp.neighborlqilist.map((neighbor) => ({
                     ieeeAddr: neighbor.extAddr,
                     lqi: neighbor.lqi,
-                };
+                }));
             });
-        }).nodeify(callback);
     }
 
     remove(ieeeAddr, cfg, callback) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -541,15 +541,19 @@ module.exports = class Controller extends EventEmitter {
             });
     }
 
-    registerEp(loEp, callback) {
-        if (!(loEp instanceof Coordpoint)) {
-            throw new TypeError('loEp should be an instance of Coordpoint class.');
-        }
-
-        return this.request('AF', 'register', makeRegParams(loEp))
-            .then((rsp) => rsp)
-            .fail((err) => (err.message === 'rsp error: 184') ? this.reRegisterEp(loEp) : Q.reject(err))
-            .nodeify(callback);
+    registerEp(loEp) {
+        return Promise.resolve()
+            .then(() => {
+                if (!(loEp instanceof Coordpoint)) {
+                    throw new TypeError('loEp should be an instance of Coordpoint class.');
+                }
+            })
+            .then(() => this.request('AF', 'register', makeRegParams(loEp)))
+            .catch((err) => {
+                return err.message === 'rsp error: 184'
+                    ? this.reRegisterEp(loEp)
+                    : Promise.reject(err);
+            });
     }
 
     deregisterEp(loEp, callback) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -494,48 +494,51 @@ module.exports = class Controller extends EventEmitter {
             });
     }
 
-    remove(dev, cfg, callback) {
+    remove(dev, cfg) {
         // cfg: { reJoin, rmChildren }
-        let reqArgObj;
         let rmChildren = 0x00;
 
-        if (!(dev instanceof Device)) {
-            throw new TypeError('dev should be an instance of Device class.');
-        } else if (!_.isPlainObject(cfg)) {
-            throw new TypeError('cfg should be an object.');
-        }
+        return Promise.resolve()
+            .then(() => {
+                if (!(dev instanceof Device)) {
+                    throw new TypeError('dev should be an instance of Device class.');
+                }
 
-        // defaults to true
-        cfg.reJoin = cfg.hasOwnProperty('reJoin')
-            ? !!cfg.reJoin
-            : true;
-
-        // defaults to false
-        cfg.rmChildren = cfg.hasOwnProperty('rmChildren')
-            ? !!cfg.rmChildren
-            : false;
-
-        rmChildren = cfg.reJoin
-            ? (rmChildren | 0x01)
-            : rmChildren;
-
-        rmChildren = cfg.rmChildren
-            ? (rmChildren | 0x02)
-            : rmChildren;
-
-        reqArgObj = {
-            dstaddr: dev.getNwkAddr(),
-            deviceaddress: dev.getIeeeAddr(),
-            removechildren_rejoin: rmChildren,
-        };
-
-        return this.request('ZDO', 'mgmtLeaveReq', reqArgObj)
-            .then((rsp) => {
-                if (rsp.status !== 0 && rsp.status !== 'SUCCESS') {
-                    return Q.reject(rsp.status);
+                if (!_.isPlainObject(cfg)) {
+                    throw new TypeError('cfg should be an object.');
                 }
             })
-            .nodeify(callback);
+            .then(() => {
+                // defaults to true
+                cfg.reJoin = cfg.hasOwnProperty('reJoin')
+                    ? !!cfg.reJoin
+                    : true;
+
+                // defaults to false
+                cfg.rmChildren = cfg.hasOwnProperty('rmChildren')
+                    ? !!cfg.rmChildren
+                    : false;
+
+                rmChildren = cfg.reJoin
+                    ? (rmChildren | 0x01)
+                    : rmChildren;
+
+                rmChildren = cfg.rmChildren
+                    ? (rmChildren | 0x02)
+                    : rmChildren;
+
+                return {
+                    dstaddr: dev.getNwkAddr(),
+                    deviceaddress: dev.getIeeeAddr(),
+                    removechildren_rejoin: rmChildren,
+                };
+            })
+            .then((reqArgObj) => this.request('ZDO', 'mgmtLeaveReq', reqArgObj))
+            .then((rsp) => {
+                if (rsp.status !== 0 && rsp.status !== 'SUCCESS') {
+                    return Promise.reject(rsp.status);
+                }
+            });
     }
 
     registerEp(loEp, callback) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -556,31 +556,33 @@ module.exports = class Controller extends EventEmitter {
             });
     }
 
-    deregisterEp(loEp, callback) {
+    deregisterEp(loEp) {
         const coordEps = this.getCoord().endpoints;
 
-        if (!(loEp instanceof Coordpoint)) {
-            throw new TypeError('loEp should be an instance of Coordpoint class.');
-        }
+        return Promise.resolve()
+            .then(() => {
+                if (!(loEp instanceof Coordpoint)) {
+                    throw new TypeError('loEp should be an instance of Coordpoint class.');
+                }
+            })
+            .then(() => {
+                if (!_.includes(coordEps, loEp)) {
+                    throw new Error('Endpoint not maintained by Coordinator, cannot be removed.');
+                }
 
-        return Q.fcall(() => {
-            if (!_.includes(coordEps, loEp)) {
-                return Q.reject(new Error('Endpoint not maintained by Coordinator, cannot be removed.'));
-            }
-
-            return this.request('AF', 'delete', {
-                endpoint: loEp.getEpId(),
+                return this.request('AF', 'delete', {
+                    endpoint: loEp.getEpId(),
+                });
+            })
+            .then((rsp) => {
+                delete coordEps[loEp.getEpId()];
+                return rsp;
             });
-        }).then((rsp) => {
-            delete coordEps[loEp.getEpId()];
-            return rsp;
-        }).nodeify(callback);
     }
 
-    reRegisterEp(loEp, callback) {
+    reRegisterEp(loEp) {
         return this.deregisterEp(loEp)
-            .then(() => this.request('AF', 'register', makeRegParams(loEp)))
-            .nodeify(callback);
+            .then(() => this.request('AF', 'register', makeRegParams(loEp)));
     }
 
     simpleDescReq(nwkAddr, ieeeAddr, callback) {

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -259,16 +259,15 @@ describe('Bridge Top Level of Tests', function() {
         });
 
         describe('#.lqi', function() {
-            it('should throw if ieeeAddr is not a string', function() {
-                expect(function() {
-                    bridge.lqi({});
-                }).to.throw(TypeError);
-                expect(function() {
-                    bridge.lqi(true);
-                }).to.throw(TypeError);
-                expect(function() {
-                    bridge.lqi('ceed');
-                }).not.to.throw(TypeError);
+            it('should throw if ieeeAddr is not a string', () => {
+                return Promise.all([
+                    bridge.lqi({})
+                        .catch((e) => expect(e).to.be.instanceof(TypeError)),
+                    bridge.lqi(true)
+                        .catch((e) => expect(e).to.be.instanceof(TypeError)),
+                    bridge.lqi('ceed')
+                        .catch((e) => expect(e).to.be.instanceof(Error)),
+                ]);
             });
         });
 
@@ -486,14 +485,13 @@ describe('Bridge Top Level of Tests', function() {
                     return deferred.promise.nodeify(callback);
                 });
 
-                bridge.lqi('0x00137a00000161f2', function(err, data) {
-                    if (!err) {
+                bridge.lqi('0x00137a00000161f2')
+                    .then((data) =>{
                         expect(data[0].ieeeAddr).to.be.equal('0x0123456789abcdef');
                         expect(data[0].lqi).to.be.equal(123);
                         requestStub.restore();
                         done();
-                    }
-                });
+                    });
             });
         });
 

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -271,17 +271,16 @@ describe('Bridge Top Level of Tests', function() {
             });
         });
 
-        describe('#.remove', function() {
-            it('should throw if ieeeAddr is not a string', function() {
-                expect(function() {
-                    bridge.remove({});
-                }).to.throw(TypeError);
-                expect(function() {
-                    bridge.remove(true);
-                }).to.throw(TypeError);
-                expect(function() {
-                    bridge.remove('ceed');
-                }).not.to.throw(TypeError);
+        describe('#.remove', () => {
+            it('should throw if ieeeAddr is not a string', () => {
+                return Promise.all([
+                    bridge.remove({})
+                        .catch((e) => expect(e).to.be.instanceof(TypeError)),
+                    bridge.remove(true)
+                        .catch((e) => expect(e).to.be.instanceof(TypeError)),
+                    bridge.remove('ceed')
+                        .catch((e) => expect(e).to.be.instanceof(Error)),
+                ]);
             });
         });
     });
@@ -454,12 +453,12 @@ describe('Bridge Top Level of Tests', function() {
             });
         });
 
-        describe('#.lqi', function() {
-            it('should get lqi of the device', function(done) {
-                let requestStub = sinon.stub(bridge.controller, 'request', function(subsys, cmdId, valObj, callback) {
+        describe('#.lqi', () => {
+            it('should get lqi of the device', (done) => {
+                let requestStub = sinon.stub(bridge.controller, 'request', (subsys, cmdId, valObj, callback) => {
                     let deferred = Q.defer();
 
-                    process.nextTick(function() {
+                    process.nextTick(() => {
                         deferred.resolve({
                             srcaddr: 100,
                             status: 0,
@@ -495,24 +494,23 @@ describe('Bridge Top Level of Tests', function() {
             });
         });
 
-        describe('#.remove', function() {
-            it('should remove the device', function(done) {
-                let requestStub = sinon.stub(bridge.controller, 'request', function(subsys, cmdId, valObj, callback) {
+        describe('#.remove', () => {
+            it('should remove the device', (done) => {
+                let requestStub = sinon.stub(bridge.controller, 'request', (subsys, cmdId, valObj, callback) => {
                     let deferred = Q.defer();
 
-                    process.nextTick(function() {
+                    process.nextTick(() => {
                         deferred.resolve({srcaddr: 100, status: 0});
                     });
 
                     return deferred.promise.nodeify(callback);
                 });
 
-                bridge.remove('0x00137a00000161f2', function(err) {
-                    if (!err) {
+                bridge.remove('0x00137a00000161f2')
+                    .then(() =>{
                         requestStub.restore();
                         done();
-                    }
-                });
+                    });
             });
         });
 

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -432,55 +432,43 @@ describe('Signature Check', function() {
         });
     });
 
-    describe('#.registerEp', function() {
-        it('should be a function', function() {
+    describe('#.registerEp', () => {
+        it('should be a function', () => {
             expect(controller.registerEp).to.be.a('function');
         });
 
-        it('should throw if loEp is not a Coorpoint', function() {
-            expect(function() {
-                return controller.registerEp('x', function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp([], function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp({}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(undefined, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(null, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(NaN, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(true, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(new Date(), function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(function() {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(rmEp1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(rmEp2, function() {});
-            }).to.throw(TypeError);
+        it('should throw if loEp is not a Coorpoint', () => {
+            return Promise.all([
+                controller.registerEp('x')
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp([])
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp({})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(undefined)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(null)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(NaN)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(true)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(new Date())
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(function() {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(rmEp1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.registerEp(rmEp2)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
 
-            expect(function() {
-                return controller.registerEp(loEp1, function() {});
-            }).not.to.throw(TypeError);
-            expect(function() {
-                return controller.registerEp(loEp8, function() {});
-            }).not.to.throw(TypeError);
+                controller.registerEp(loEp1)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+                controller.registerEp(loEp8)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+            ]);
         });
     });
 
@@ -1110,26 +1098,25 @@ describe('Functional Check', function() {
         });
     });
 
-    describe('#.registerEp', function() {
-        it('register loEp1', function(done) {
-            let requestStub = sinon.stub(controller, 'request', function(subsys, cmdId, valObj, callback) {
+    describe('#.registerEp', () => {
+        it('register loEp1', (done) => {
+            let requestStub = sinon.stub(controller, 'request', (subsys, cmdId, valObj, callback) => {
                 let deferred = Q.defer();
 
                 expect(cmdId).to.be.equal('register');
 
-                setImmediate(function() {
+                setImmediate(() => {
                     deferred.resolve({status: 0});
                 });
 
                 return deferred.promise.nodeify(callback);
             });
 
-            controller.registerEp(loEp1, function(err) {
-                if (!err) {
+            controller.registerEp(loEp1)
+                .then(() => {
                     requestStub.restore();
                     done();
-                }
-            });
+                });
         });
     });
 

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -846,72 +846,57 @@ describe('Signature Check', function() {
         });
     });
 
-    describe('#.remove', function() {
+    describe('#.remove', () => {
         it('should be a function', function() {
             expect(controller.remove).to.be.a('function');
         });
 
-        it('should throw if dev is not a Device', function() {
-            expect(function() {
-                return controller.remove('x', {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(1, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove([], {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove({}, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(undefined, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(null, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(NaN, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(true, {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(new Date(), {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(function() {}, {}, function() {});
-            }).to.throw(TypeError);
+        it('should throw if dev is not a Device', () => {
+            return Promise.all([
+                controller.remove('x', {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(1, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove([], {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove({}, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(undefined, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(null, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(true, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(NaN, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(new Date(), {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(() => {}, {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+            ]);
         });
 
-        it('should throw if cfg is not an object', function() {
-            expect(function() {
-                return controller.remove(remoteDev, 'x', function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, 1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, [], function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, undefined, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, null, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, NaN, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, true, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, new Date(), function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.remove(remoteDev, function() {}, function() {});
-            }).to.throw(TypeError);
+        it('should throw if cfg is not an object', () => {
+            return Promise.all([
+                controller.remove(remoteDev, 'x')
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, 1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, [])
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, undefined)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, null)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, NaN)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, true)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, new Date())
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.remove(remoteDev, function() {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+            ]);
         });
     });
 });
@@ -1103,26 +1088,25 @@ describe('Functional Check', function() {
         });
     });
 
-    describe('#.remove', function() {
-        it('remove device', function(done) {
-            let requestStub = sinon.stub(controller, 'request', function(subsys, cmdId, valObj, callback) {
+    describe('#.remove', () => {
+        it('remove device', (done) => {
+            let requestStub = sinon.stub(controller, 'request', (subsys, cmdId, valObj, callback) => {
                 let deferred = Q.defer();
 
                 expect(valObj.deviceaddress).to.be.equal('0x123456789abcdef');
 
-                setImmediate(function() {
+                setImmediate(() => {
                     deferred.resolve({status: 0});
                 });
 
                 return deferred.promise.nodeify(callback);
             });
 
-            controller.remove(remoteDev, {}, function(err) {
-                if (!err) {
+            controller.remove(remoteDev, {})
+                .then((err) => {
                     requestStub.restore();
                     done();
-                }
-            });
+                });
         });
     });
 

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -472,107 +472,83 @@ describe('Signature Check', function() {
         });
     });
 
-    describe('#.deregisterEp', function() {
-        it('should be a function', function() {
+    describe('#.deregisterEp', () => {
+        it('should be a function', () => {
             expect(controller.deregisterEp).to.be.a('function');
         });
 
-        it('should throw if loEp is not a Coorpoint', function() {
-            expect(function() {
-                return controller.deregisterEp('x', function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp([], function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp({}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(undefined, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(null, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(NaN, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(true, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(new Date(), function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(function() {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(rmEp1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(rmEp2, function() {});
-            }).to.throw(TypeError);
+        it('should throw if loEp is not a Coorpoint', () => {
+            return Promise.all([
+                controller.deregisterEp('x')
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp([])
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp({})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(undefined)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(null)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(NaN)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(true)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(new Date())
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(function() {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(rmEp1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.deregisterEp(rmEp2)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
 
-            expect(function() {
-                return controller.deregisterEp(loEp1, function() {});
-            }).not.to.throw(TypeError);
-            expect(function() {
-                return controller.deregisterEp(loEp8, function() {});
-            }).not.to.throw(TypeError);
+                controller.deregisterEp(loEp1)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+                controller.deregisterEp(loEp8)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+            ]);
         });
     });
 
-    describe('#.reRegisterEp', function() {
-        it('should be a function', function() {
+    describe('#.reRegisterEp', () => {
+        it('should be a function', () => {
             expect(controller.reRegisterEp).to.be.a('function');
         });
 
-        it('should throw if loEp is not a Coorpoint', function() {
-            expect(function() {
-                return controller.reRegisterEp('x', function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp([], function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp({}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(undefined, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(null, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(NaN, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(true, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(new Date(), function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(function() {}, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(rmEp1, function() {});
-            }).to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(rmEp2, function() {});
-            }).to.throw(TypeError);
+        it('should throw if loEp is not a Coorpoint', () => {
+            return Promise.all([
+                controller.reRegisterEp('x')
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp([])
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp({})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(undefined)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(null)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(NaN)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(true)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(new Date())
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(function() {})
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(rmEp1)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
+                controller.reRegisterEp(rmEp2)
+                    .catch((err) => expect(err).to.be.instanceof(TypeError)),
 
-            expect(function() {
-                return controller.reRegisterEp(loEp1, function() {});
-            }).not.to.throw(TypeError);
-            expect(function() {
-                return controller.reRegisterEp(loEp8, function() {});
-            }).not.to.throw(TypeError);
+                controller.reRegisterEp(loEp1)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+                controller.reRegisterEp(loEp8)
+                    .catch((err) => expect(err).to.be.instanceof(Error)),
+            ]);
         });
     });
 
@@ -1120,14 +1096,14 @@ describe('Functional Check', function() {
         });
     });
 
-    describe('#.deregisterEp', function() {
-        it('delete loEp1', function(done) {
-            let requestStub = sinon.stub(controller, 'request', function(subsys, cmdId, valObj, callback) {
+    describe('#.deregisterEp', () => {
+        it('delete loEp1', (done) => {
+            let requestStub = sinon.stub(controller, 'request', (subsys, cmdId, valObj, callback) => {
                 let deferred = Q.defer();
 
                 expect(cmdId).to.be.equal('delete');
 
-                setImmediate(function() {
+                setImmediate(() => {
                     deferred.resolve({status: 0});
                 });
 
@@ -1136,21 +1112,20 @@ describe('Functional Check', function() {
 
             controller.getCoord().endpoints[1] = loEp1;
 
-            controller.deregisterEp(loEp1, function(err) {
-                if (!err) {
+            controller.deregisterEp(loEp1)
+                .then(() => {
                     requestStub.restore();
                     done();
-                }
-            });
+                });
         });
     });
 
-    describe('#.reRegisterEp', function() {
-        it('reRegister loEp1', function(done) {
-            let requestStub = sinon.stub(controller, 'request', function(subsys, cmdId, valObj, callback) {
+    describe('#.reRegisterEp', () => {
+        it('reRegister loEp1', (done) => {
+            let requestStub = sinon.stub(controller, 'request', (subsys, cmdId, valObj, callback) => {
                 let deferred = Q.defer();
 
-                setImmediate(function() {
+                setImmediate(() => {
                     deferred.resolve({status: 0});
                 });
 
@@ -1158,7 +1133,7 @@ describe('Functional Check', function() {
             });
 
 
-            let deregisterEpStub = sinon.stub(controller, 'deregisterEp', function(loEp, callback) {
+            let deregisterEpStub = sinon.stub(controller, 'deregisterEp', (loEp, callback) => {
                 let deferred = Q.defer();
 
                 setImmediate(function() {
@@ -1168,13 +1143,12 @@ describe('Functional Check', function() {
                 return deferred.promise.nodeify(callback);
             });
 
-            controller.reRegisterEp(loEp1, function(err) {
-                if (!err) {
+            controller.reRegisterEp(loEp1)
+                .then(() => {
                     requestStub.restore();
                     deregisterEpStub.restore();
                     done();
-                }
-            });
+                });
         });
     });
 


### PR DESCRIPTION
Added native promises support instead of Q for lqi/remove/registerEp/deregisterEp/reRegisterEp.